### PR TITLE
Using Yubikey without password auth

### DIFF
--- a/lib/devise_yubikey_database_authenticatable/strategy.rb
+++ b/lib/devise_yubikey_database_authenticatable/strategy.rb
@@ -4,13 +4,13 @@ module Devise
   module Strategies
     class YubikeyDatabaseAuthenticatable < Authenticatable
       def authenticate!
-        resource = valid_password? && mapping.to.find_for_yubikey_database_authentication(authentication_hash)
+        resource = mapping.to.find_for_yubikey_database_authentication(authentication_hash)
         return fail(:not_found_in_database) unless resource
 
-        if validate(resource) { resource.valid_password?(password) }
+        if validate(resource)
           if resource.use_yubikey?
             if params[scope][:yubiotp].blank?
-              fail('Yubikey OTP Required for this user.')
+              resource.valid_password?(password) 
             else
               if resource.validate_yubikey(params[scope][:yubiotp]) && (resource.registered_yubikey == params[scope][:yubiotp][0..11])
                 resource.after_database_authentication


### PR DESCRIPTION
When using yubikey OR a password needed to remove the resource = valid_password? and also change the resource.valid_password?(password) after validate(resource) since the password may be blank if using the Yubikey only for auth.
